### PR TITLE
Fix helping (main form) UI will come out after starting

### DIFF
--- a/CapsLockSharpPrototype/MainForm.Designer.cs
+++ b/CapsLockSharpPrototype/MainForm.Designer.cs
@@ -34,9 +34,11 @@ namespace CapsLockSharpPrototype
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.helpMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.startWithSystem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.quitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -45,7 +47,6 @@ namespace CapsLockSharpPrototype
             this.keysListView = new System.Windows.Forms.ListView();
             this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.startWithSystem = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
             this.splitContainer.Panel1.SuspendLayout();
@@ -69,7 +70,7 @@ namespace CapsLockSharpPrototype
             this.toolStripMenuItem2,
             this.quitMenuItem});
             this.contextMenuStrip.Name = "contextMenuStrip";
-            this.contextMenuStrip.Size = new System.Drawing.Size(181, 120);
+            this.contextMenuStrip.Size = new System.Drawing.Size(125, 98);
             // 
             // helpMenuItem
             // 
@@ -77,6 +78,14 @@ namespace CapsLockSharpPrototype
             this.helpMenuItem.Size = new System.Drawing.Size(124, 22);
             this.helpMenuItem.Text = "帮助";
             this.helpMenuItem.Click += new System.EventHandler(this.HelpMenuItem_Click);
+            // 
+            // startWithSystem
+            // 
+            this.startWithSystem.CheckOnClick = true;
+            this.startWithSystem.Name = "startWithSystem";
+            this.startWithSystem.Size = new System.Drawing.Size(124, 22);
+            this.startWithSystem.Text = "开机启动";
+            this.startWithSystem.CheckedChanged += new System.EventHandler(this.startWithSystem_CheckedChanged);
             // 
             // aboutMenuItem
             // 
@@ -156,14 +165,6 @@ namespace CapsLockSharpPrototype
             this.columnHeader2.Text = "替换为";
             this.columnHeader2.Width = 144;
             // 
-            // startWithSystem
-            // 
-            this.startWithSystem.CheckOnClick = true;
-            this.startWithSystem.Name = "startWithSystem";
-            this.startWithSystem.Size = new System.Drawing.Size(180, 22);
-            this.startWithSystem.Text = "开机启动";
-            this.startWithSystem.CheckedChanged += new System.EventHandler(this.startWithSystem_CheckedChanged);
-            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 17F);
@@ -172,10 +173,9 @@ namespace CapsLockSharpPrototype
             this.ClientSize = new System.Drawing.Size(289, 378);
             this.Controls.Add(this.splitContainer);
             this.Font = new System.Drawing.Font("微软雅黑", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "MainForm";
-            this.ShowIcon = false;
-            this.ShowInTaskbar = false;
             this.Text = "帮助";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
             this.Load += new System.EventHandler(this.MainForm_Load);

--- a/CapsLockSharpPrototype/MainForm.cs
+++ b/CapsLockSharpPrototype/MainForm.cs
@@ -8,16 +8,23 @@ namespace CapsLockSharpPrototype
 {
     public partial class MainForm : Form
     {
-
-
         public static NotifyIcon NotifyIcon { get; private set; }
         public string AppName { get; private set; } = "Caplos";
-        
+        private bool windowCreate = true;
+
+        protected override void OnActivated(EventArgs e)
+        {
+            if (windowCreate)
+            {
+                base.Visible = false;
+                windowCreate = false;
+            }
+            base.OnActivated(e);
+        }
 
         public MainForm()
         {
             InitializeComponent();
-            WindowState = FormWindowState.Minimized;
             Helper.KeyDefRuntime.KeyDefs = Helper.KeyDefRuntime.SetUpKeyDefs();
             TrayIcon.RefleshIcon(notifyIcon);
         }
@@ -33,24 +40,24 @@ namespace CapsLockSharpPrototype
         {
             foreach (var item in KeyDefRuntime.KeyDefs)
             {
-                if(item.Type == KeyDefRuntime.FuncType.Replace)
+                if (item.Type == KeyDefRuntime.FuncType.Replace)
                 {
                     keysListView.Items.Add(new ListViewItem(new[] { $"[CapsLock] + {item.AdditionKey.ToString()}", item.ReplacingKey.ToString() }));
                 }
-                
             }
             NotifyIcon = notifyIcon;
             Program.GlobalController = new Controller();
-            Program.GlobalController.SetupKeyboardHooks((x,y)=> {
+            Program.GlobalController.SetupKeyboardHooks((x, y) =>
+            {
                 TrayIcon.RefleshIcon(notifyIcon);
             });
             CheckStartWithSystem();
         }
+
         private void CheckStartWithSystem()
         {
-            startWithSystem.Checked = AutoStart.CheckEnabled(AppName);            
+            startWithSystem.Checked = AutoStart.CheckEnabled(AppName);
         }
-
 
         private void AboutMenuItem_Click(object sender, EventArgs e)
         {
@@ -58,6 +65,7 @@ namespace CapsLockSharpPrototype
             x.ShowDialog();
             x.Dispose();
         }
+
         private void NotifyIcon_MouseDoubleClick(object sender, MouseEventArgs e)
         {
             Show();
@@ -94,13 +102,14 @@ namespace CapsLockSharpPrototype
         private void startWithSystem_CheckedChanged(object sender, EventArgs e)
         {
             var currentEnabled = AutoStart.CheckEnabled(AppName);
-            if(startWithSystem.Checked == currentEnabled)
+            if (startWithSystem.Checked == currentEnabled)
             {
                 return;
             }
+
             if (startWithSystem.Checked)
             {
-               AutoStart.Enable(AppName, "\"" + Application.ExecutablePath + "\"");
+                AutoStart.Enable(AppName, "\"" + Application.ExecutablePath + "\"");
             }
             else
             {


### PR DESCRIPTION
## Issues

see #8 

> 还有就是启动的时候 会自动打开 键盘的提示操作按键，（帮助）每次都要手动关闭，感觉很麻烦。

同样反感该 **bug**

## How to do

see https://blog.csdn.net/wangjiong/article/details/1046615

## Changelogs

1. 不显示帮助窗口在启动时
2. 使帮助窗口显示在任务栏上
3. 帮助窗口显示 icon

## License

望 @pluveto 明确 [Caplos](https://github.com/pluveto/Caplos) 项目开源协议, 减少未来可能的不必要的冲突. 🤝